### PR TITLE
Simulation with loaded PBS bugfix

### DIFF
--- a/tnfs_engine.c
+++ b/tnfs_engine.c
@@ -90,7 +90,7 @@ void tnfs_engine_auto_shift_change(tnfs_car_data *car_data, tnfs_car_specs *car_
 	// speed to RPM
 	rpm_vehicle = fixmul(fixmul(car_specs->gear_ratio_table[gear + 2], car_specs->mps_to_rpm_factor), car_data->speed_local_lon) >> 16;
 
-	if (gear < car_specs->number_of_gears && rpm_vehicle > car_specs->gear_upshift_rpm[gear]) {
+	if (gear < (car_specs->number_of_gears - 3) && rpm_vehicle > car_specs->gear_upshift_rpm[gear]) {
 		// upshift
 		car_data->gear_selected++;
 	} else if (gear > 0 && rpm_vehicle < car_specs->gear_upshift_rpm[gear] / 2) {
@@ -133,7 +133,7 @@ int tnfs_engine_torque(tnfs_car_specs *specs, int rpm) {
 	if (rpm < specs->torque_table[0]) {
 		offset = 0;
 	} else {
-		offset = (rpm - specs->torque_table[0]) / 200;
+		offset = (rpm - specs->torque_table[0]) / 400;
 	}
 
 	if (offset < 0) {

--- a/tnfs_engine.c
+++ b/tnfs_engine.c
@@ -93,7 +93,7 @@ void tnfs_engine_auto_shift_change(tnfs_car_data *car_data, tnfs_car_specs *car_
 	if (gear < (car_specs->number_of_gears - 3) && rpm_vehicle > car_specs->gear_upshift_rpm[gear]) {
 		// upshift
 		car_data->gear_selected++;
-	} else if (gear > 0 && rpm_vehicle < car_specs->gear_upshift_rpm[gear] / 2) {
+	} else if (gear > 0 && rpm_vehicle < car_specs->gear_upshift_rpm[gear - 1] / 2) {
 		// downshift
 		car_data->gear_selected--;
 	}

--- a/tnfs_files.c
+++ b/tnfs_files.c
@@ -108,7 +108,7 @@ int read_pbs_file(char * file) {
 	car_specs.final_drive = readFixed32(buffer, 0x5c);
 	car_specs.inverse_wheel_radius = readFixed32(buffer, 0x64);
 
-	for (i = 0; i <= 8; i++) {
+	for (i = 0; i < 8; i++) {
 		car_specs.gear_ratio_table[i] = readFixed32(buffer, i * 4 + 0x68);
 	}
 
@@ -120,13 +120,13 @@ int read_pbs_file(char * file) {
 	car_specs.rpm_redline = readFixed32(buffer, 0xac);
 	car_specs.rpm_idle = readFixed32(buffer, 0xb0);
 
-	for (i = 0; i <= car_specs.torque_table_entries; i++) {
+	for (i = 0; i < (car_specs.torque_table_entries * 2); i++) {
 		car_specs.torque_table[i] = readFixed32(buffer, i * 4 + 0xb4);
 	}
-	for (i = 0; i <= 6; i++) {
+	for (i = 0; i < 7; i++) {
 		car_specs.gear_upshift_rpm[i] = readFixed32(buffer, i * 4 + 0x294);
 	}
-	for (i = 0; i <= 8; i++) {
+	for (i = 0; i < 8; i++) {
 		car_specs.gear_efficiency[i] = readFixed32(buffer, i * 4 + 0x2b0);
 	}
 


### PR DESCRIPTION
Major fixes performed:
1) in torque table, at least for TNFS SE (PC) `PBS` files, RPM values are incremented by 400, not 200. That's why car with real PBS cannot reach upshift RPM. Fixed table lookup code. Let me know if other PBS files have RPM incremented by 200, in this case you should probably loop over table
2)  fixed upshift logic: in real PBS, for last gear and next ones the value is very high (or negative in case we are using signed int, we are actually), so current logic immediately shifts to 8 gear and simulation gets broken. The problem is gear comparing to num of gears: `car_specs->number_of_gears` equals to number of gears + 2, `gear` is 0 for 1st drive gear, 1 for 2nd etc. So for 5 gears car on 5th gear, `gear == 4`, `number_of_gears == 7`, we should never upshift on this gear, so I compare gear against `number_of_gears - 3`
3) the same for downshift. The upshift for last gear is negative (or huge positive if unsigned), so current downshift logic simply does not work: car performs downshift immediately after shifting to last gear. I use previous gear upshift value instead, the value for all gears seem to be the same in the real `PBS` files 

Minor fixes:
1) fixed `gear_ratio_table` filling: fill all 8 values, not 9
2) fixed `torque_table` filling: read all values, not half of them
3) fixed `gear_efficiency` filling: fill all 8 values, not 9
4) changed `gear_upshift_rpm` fill loop condition to be consistent with other loops like this one