### PR TITLE
Support of 0 to 7 ai racers; start position

### DIFF
--- a/tnfs_ai.c
+++ b/tnfs_ai.c
@@ -1429,7 +1429,7 @@ void tnfs_ai_lane_change() {
  */
 void tnfs_ai_driver_update(tnfs_car_data *car) {
 	tnfs_ai_update_vectors(car);
-	tnfs_ai_lane_change(car);
+	tnfs_ai_lane_change();
 	tnfs_ai_main(car);
 	tnfs_track_fence_collision(car);
 }

--- a/tnfs_ai.c
+++ b/tnfs_ai.c
@@ -46,8 +46,8 @@ void tnfs_ai_init() {
     //g_car_ptr_array[i]->field_174 |= 0x1000; //backwards
     //g_car_ptr_array[i]->field_174 |= 0x20000; //stopped
 
-    for (i = 0; i <= 99; i++) {
-      g_car_ptr_array[i]->power_curve[i] = g_power_curve[i >> 2];
+    for (int j = 0; j < 100; j++) {
+      g_car_ptr_array[i]->power_curve[j] = g_power_curve[j >> 2];
     }
 	}
 

--- a/tnfs_ai.c
+++ b/tnfs_ai.c
@@ -28,8 +28,6 @@ int DAT_001670B3 = 0;
 int DAT_001670BB = 0;
 
 tnfs_car_data* player_car_ptr;
-tnfs_car_data* g_car_ptr_array[2]; // 00153ba0/00153bec 8010c720/800f7e60
-int g_total_cars_in_scene = 2; // 8010d1d4
 
 int g_power_curve[] = { 0x5062, 0x4f1a, 0x4f1a, 0x55c2, 0x2937, 0x2c49, 0x28f5, 0x228f, 0x1df3, 0x19db, 0x7a14, 0x12f1, 0x11eb, //
 		0xffd, 0xdf4, 0xc8b, 0xb43, 0x978, 0x7ae, 0x69e, 0x5e3, 0x560, 0x45a, 0x418, 0 };
@@ -39,21 +37,21 @@ void tnfs_ai_init() {
 
 	player_car_ptr = &player_car;
 
-	xman_car_data.field_174 = 0x1e4;
-	//xman_car_data.field_174 |= 4; // run
-	//xman_car_data.field_174 |= 8; //
-	//xman_car_data.field_174 |= 0x404; //steer more
-	//xman_car_data.field_174 |= 0x408; //
-	//xman_car_data.field_174 |= 0x1000; //backwards
-	//xman_car_data.field_174 |= 0x20000; //stopped
+	for (i = 1; i < g_total_cars_in_scene; i++) {
+    g_car_ptr_array[i]->field_174 = 0x1e4;
+    //g_car_ptr_array[i]->field_174 |= 4; // run
+    //g_car_ptr_array[i]->field_174 |= 8; //
+    //g_car_ptr_array[i]->field_174 |= 0x404; //steer more
+    //g_car_ptr_array[i]->field_174 |= 0x408; //
+    //g_car_ptr_array[i]->field_174 |= 0x1000; //backwards
+    //g_car_ptr_array[i]->field_174 |= 0x20000; //stopped
 
-	for (i = 0; i <= 99; i++) {
-		xman_car_data.power_curve[i] = g_power_curve[i >> 2];
+    for (i = 0; i <= 99; i++) {
+      g_car_ptr_array[i]->power_curve[i] = g_power_curve[i >> 2];
+    }
 	}
 
 	// globals
-	g_car_ptr_array[0] = &player_car;
-	g_car_ptr_array[1] = &xman_car_data;
 	player_car_ptr = &player_car;
 }
 
@@ -1431,9 +1429,9 @@ void tnfs_ai_lane_change() {
 /*
  * minimal routines for the X-man driver
  */
-void tnfs_ai_driver_update() {
-	tnfs_ai_update_vectors(&xman_car_data);
+void tnfs_ai_driver_update(tnfs_car_data *car) {
+	tnfs_ai_update_vectors(car);
 	tnfs_ai_lane_change();
-	tnfs_ai_main(&xman_car_data);
-	tnfs_track_fence_collision(&xman_car_data);
+	tnfs_ai_main(car);
+	tnfs_track_fence_collision(car);
 }

--- a/tnfs_ai.c
+++ b/tnfs_ai.c
@@ -35,8 +35,6 @@ int g_power_curve[] = { 0x5062, 0x4f1a, 0x4f1a, 0x55c2, 0x2937, 0x2c49, 0x28f5, 
 void tnfs_ai_init() {
 	int i;
 
-	player_car_ptr = &player_car;
-
 	for (i = 1; i < g_total_cars_in_scene; i++) {
     g_car_ptr_array[i]->field_174 = 0x1e4;
     //g_car_ptr_array[i]->field_174 |= 4; // run
@@ -52,7 +50,7 @@ void tnfs_ai_init() {
 	}
 
 	// globals
-	player_car_ptr = &player_car;
+	player_car_ptr = g_car_ptr_array[0];
 }
 
 void FUN_0044E11() {
@@ -369,7 +367,7 @@ void tnfs_ai_drive_car(tnfs_car_data *car, int curr_state) {
 			car->car_road_speed -= accel * iVar4;
 			if (car->car_road_speed <= car->speed_target)
 				car->car_road_speed = car->speed_target;
-			if (ai_type && car->car_data_ptr->field_4e1 == 3 && car->car_road_speed - 0xa0000 > car->speed_target) {
+			if (ai_type && car->field_4e1 == 3 && car->car_road_speed - 0xa0000 > car->speed_target) {
 				car->brake = 0x11;
 			}
 		}
@@ -664,7 +662,7 @@ void tnfs_ai_main(tnfs_car_data *car) {
 			max_steer = 0x160000;
 
 		if (abs(car->steer_angle) > max_steer && (car->field_174 & 0x200000) == 0) {
-			FUN_0044E11(car->car_data_ptr);
+			FUN_0044E11(car);
 			if (car->field_174 & 8) {
 				if (FUN_0076FB9(car->road_segment_a))
 					tnfs_replay_highlight_record(0x52);
@@ -1412,7 +1410,7 @@ void tnfs_ai_lane_change() {
 								car->target_center_line -= car->field_33c;
 
 				            //if ((DAT_00165148 != 0) && (local_c0 != lane)) {
-				            //  FUN_00077a05(car,&player_car, local_c0, &car_speed_a);
+				            //  FUN_00077a05(car,g_car_ptr_array[0], local_c0, &car_speed_a);
 				            //}
 				            //if (((car->field_174 & 4) != 0) && (car->road_segment_b < 0x41)) {
 				            //  car->speed_target = ((0x10000 + 2016 * (65 - car->road_segment_b)) * car->speed_target + 0x8000) >> 16;
@@ -1431,7 +1429,7 @@ void tnfs_ai_lane_change() {
  */
 void tnfs_ai_driver_update(tnfs_car_data *car) {
 	tnfs_ai_update_vectors(car);
-	tnfs_ai_lane_change();
+	tnfs_ai_lane_change(car);
 	tnfs_ai_main(car);
 	tnfs_track_fence_collision(car);
 }

--- a/tnfs_ai.h
+++ b/tnfs_ai.h
@@ -7,6 +7,6 @@
 
 
 void tnfs_ai_init();
-void tnfs_ai_driver_update();
+void tnfs_ai_driver_update(tnfs_car_data *car);
 
 #endif /* TNFS_AI_H_ */

--- a/tnfs_base.c
+++ b/tnfs_base.c
@@ -14,6 +14,8 @@ tnfs_car_data player_car;
 tnfs_track_data track_data[2400];
 tnfs_surface_type road_surface_type_array[3];
 tnfs_car_data xman_car_data;
+tnfs_car_data* g_car_ptr_array[8]; // 00153ba0/00153bec 8010c720/800f7e60
+int g_total_cars_in_scene = 2;
 
 // settings/flags
 char is_drifting;
@@ -857,6 +859,9 @@ void tnfs_init_sim(char * trifile) {
 
 	tnfs_init_track(trifile);
 
+	g_car_ptr_array[0] = &player_car;
+	g_car_ptr_array[1] = &xman_car_data;
+
 	// init player car
 	tnfs_init_car();
 	player_car.car_data_ptr = &player_car;
@@ -913,29 +918,31 @@ void tnfs_update() {
 		tnfs_collision_main(&player_car);
 	}
 
-	// opponent
-	if (xman_car_data.is_wrecked == 0) {
-		tnfs_ai_driver_update();
-	} else {
-		tnfs_collision_main(&xman_car_data);
-	}
+	// opponent(s)
+  for (int i = 1; i < g_total_cars_in_scene; i++) {
+    if (g_car_ptr_array[i]->is_wrecked == 0) {
+      tnfs_ai_driver_update(g_car_ptr_array[i]);
+    } else {
+      tnfs_collision_main(g_car_ptr_array[i]);
+    }
+  }
 
 	// tweak to allow circuit track lap
 	if (player_car.road_segment_a == road_segment_count) {
 		player_car.road_segment_a = 0;
 	}
-	if (xman_car_data.road_segment_a == road_segment_count - 5) {
-		xman_car_data.road_segment_a = 0;
+	for (int i = 1; i < g_total_cars_in_scene; i++) {
+    if (g_car_ptr_array[i]->road_segment_a == road_segment_count - 5) {
+      g_car_ptr_array[i]->road_segment_a = 0;
+    }
 	}
 
-	node = player_car.road_segment_a;
-	player_car.road_ground_position.x = track_data[node].pos.x;
-	player_car.road_ground_position.y = track_data[node].pos.y;
-	player_car.road_ground_position.z = track_data[node].pos.z;
-	node = xman_car_data.road_segment_a;
-	xman_car_data.road_ground_position.x = track_data[node].pos.x;
-	xman_car_data.road_ground_position.y = track_data[node].pos.y;
-	xman_car_data.road_ground_position.z = track_data[node].pos.z;
+  for (int i = 0; i < g_total_cars_in_scene; i++) {
+    node = g_car_ptr_array[i]->road_segment_a;
+    g_car_ptr_array[i]->road_ground_position.x = track_data[node].pos.x;
+    g_car_ptr_array[i]->road_ground_position.y = track_data[node].pos.y;
+    g_car_ptr_array[i]->road_ground_position.z = track_data[node].pos.z;
+  }
 
 	tnfs_collision_carcar();
 }

--- a/tnfs_base.c
+++ b/tnfs_base.c
@@ -15,7 +15,7 @@ tnfs_surface_type road_surface_type_array[3];
 
 tnfs_car_data g_car_array[8];
 tnfs_car_data* g_car_ptr_array[8]; // 00153ba0/00153bec 8010c720/800f7e60
-int g_total_cars_in_scene = 4;
+int g_total_cars_in_scene = 2;
 
 // settings/flags
 char is_drifting;

--- a/tnfs_base.c
+++ b/tnfs_base.c
@@ -10,12 +10,12 @@
 #include "tnfs_ai.h"
 
 tnfs_car_specs car_specs;
-tnfs_car_data player_car;
 tnfs_track_data track_data[2400];
 tnfs_surface_type road_surface_type_array[3];
-tnfs_car_data xman_car_data;
+
+tnfs_car_data g_car_array[8];
 tnfs_car_data* g_car_ptr_array[8]; // 00153ba0/00153bec 8010c720/800f7e60
-int g_total_cars_in_scene = 2;
+int g_total_cars_in_scene = 4;
 
 // settings/flags
 char is_drifting;
@@ -403,7 +403,7 @@ void tnfs_reset_car(tnfs_car_data *car) {
 	car->collision_data.angular_speed.z = 0;
 	car->collision_data.field6_0x60 = 0x10a1c;
 
-	if (car == &player_car) {
+	if (car == g_car_ptr_array[0]) {
 		car->field_4e1 = 2;
 		car->field_4e5 = 0;
 		car->field_4e9 = 4;
@@ -430,13 +430,13 @@ void tnfs_init_car() {
 		tnfs_create_car_specs();
 	}
 
-	player_car.field_4e1 = 2;
-	player_car.field_4e5 = 0;
-	player_car.field_4e9 = 4;
-	player_car.position.z = 0; //0x600000;
-	player_car.road_segment_a = 0; //0x10;
-	player_car.road_segment_b = 0; //0x10;
-	player_car.lap_number = 1;
+	g_car_array[0].field_4e1 = 2;
+	g_car_array[0].field_4e5 = 0;
+	g_car_array[0].field_4e9 = 4;
+	g_car_array[0].position.z = 0; //0x600000;
+	g_car_array[0].road_segment_a = 0; //0x10;
+	g_car_array[0].road_segment_b = 0; //0x10;
+	g_car_array[0].lap_number = 1;
 
 	// rally mode tweaks
 	if (g_selected_cheat & 0x20) {
@@ -462,53 +462,53 @@ void tnfs_init_car() {
 		i += 2;
 	} while (i < car_specs.torque_table_entries);
 
-	player_car.car_length = car_specs.body_length;
-	player_car.car_width = car_specs.body_width;
-	player_car.abs_enabled = 0;
-	player_car.tcs_enabled = 0;
-	player_car.gear_auto_selected = 0;
-	player_car.unknown_0x498 = 0;
-	player_car.drag_const_0x4a8 = 0;
-	player_car.drag_const_0x4aa = 0;
+	g_car_array[0].car_length = car_specs.body_length;
+	g_car_array[0].car_width = car_specs.body_width;
+	g_car_array[0].abs_enabled = 0;
+	g_car_array[0].tcs_enabled = 0;
+	g_car_array[0].gear_auto_selected = 0;
+	g_car_array[0].unknown_0x498 = 0;
+	g_car_array[0].drag_const_0x4a8 = 0;
+	g_car_array[0].drag_const_0x4aa = 0;
 
 	/* Fiziks_InitCar() */
 	tnfs_init_surface_constants();
 
-	player_car.weight_distribution_front = math_mul(car_specs.mass_front, car_specs.inverse_mass);
-	player_car.weight_distribution_rear = math_mul(car_specs.mass_rear, car_specs.inverse_mass);
+	g_car_array[0].weight_distribution_front = math_mul(car_specs.mass_front, car_specs.inverse_mass);
+	g_car_array[0].weight_distribution_rear = math_mul(car_specs.mass_rear, car_specs.inverse_mass);
 
 	// unused specs
-	player_car.mass_front = math_mul(car_specs.mass_total, car_specs.inverse_mass_front);
-	player_car.mass_rear = math_mul(car_specs.mass_total, car_specs.inverse_mass_rear);
+	g_car_array[0].mass_front = math_mul(car_specs.mass_total, car_specs.inverse_mass_front);
+	g_car_array[0].mass_rear = math_mul(car_specs.mass_total, car_specs.inverse_mass_rear);
 
 	// drag coefficient to deccel factor
 	car_specs.drag = math_mul(car_specs.drag, car_specs.inverse_mass);
 
-	player_car.weight_transfer_factor = math_mul(car_specs.centre_of_gravity_height, car_specs.burnOutDiv);
-	player_car.front_friction_factor = math_mul(0x9cf5c, math_mul(car_specs.front_friction_factor, player_car.weight_distribution_rear));
-	player_car.rear_friction_factor = math_mul(0x9cf5c, math_mul(car_specs.rear_friction_factor, player_car.weight_distribution_front));
+	g_car_array[0].weight_transfer_factor = math_mul(car_specs.centre_of_gravity_height, car_specs.burnOutDiv);
+	g_car_array[0].front_friction_factor = math_mul(0x9cf5c, math_mul(car_specs.front_friction_factor, g_car_array[0].weight_distribution_rear));
+	g_car_array[0].rear_friction_factor = math_mul(0x9cf5c, math_mul(car_specs.rear_friction_factor, g_car_array[0].weight_distribution_front));
 
-	player_car.drag_const_0x4ac = (short)(player_car.drag_const_0x4a8 << 1);
-	player_car.tire_grip_front = player_car.front_friction_factor;
-	player_car.tire_grip_rear = player_car.rear_friction_factor;
-	player_car.drag_const_0x4ae = (short)(player_car.drag_const_0x4aa << 1);
+	g_car_array[0].drag_const_0x4ac = (short)(g_car_array[0].drag_const_0x4a8 << 1);
+	g_car_array[0].tire_grip_front = g_car_array[0].front_friction_factor;
+	g_car_array[0].tire_grip_rear = g_car_array[0].rear_friction_factor;
+	g_car_array[0].drag_const_0x4ae = (short)(g_car_array[0].drag_const_0x4aa << 1);
 
-	player_car.drag_const_0x4a8 = fix8(fix8(car_specs.front_friction_factor) * 10 * player_car.drag_const_0x4a8);
-	player_car.drag_const_0x4aa = fix8(fix8(car_specs.rear_friction_factor) * 10 * player_car.drag_const_0x4aa);
+	g_car_array[0].drag_const_0x4a8 = fix8(fix8(car_specs.front_friction_factor) * 10 * g_car_array[0].drag_const_0x4a8);
+	g_car_array[0].drag_const_0x4aa = fix8(fix8(car_specs.rear_friction_factor) * 10 * g_car_array[0].drag_const_0x4aa);
 
 	aux = math_mul(math_mul(car_specs.wheelbase, car_specs.wheelbase), 0x324);
 
-	player_car.wheel_base = math_div(aux, car_specs.wheelbase);
-	player_car.moment_of_inertia = math_div(math_mul(aux, car_specs.inertia_factor), car_specs.wheelbase);
-	player_car.front_yaw_factor = math_div(math_mul(car_specs.wheelbase, player_car.weight_distribution_front), aux);
-	player_car.rear_yaw_factor = math_div(math_mul(car_specs.wheelbase, player_car.weight_distribution_rear), aux);
+	g_car_array[0].wheel_base = math_div(aux, car_specs.wheelbase);
+	g_car_array[0].moment_of_inertia = math_div(math_mul(aux, car_specs.inertia_factor), car_specs.wheelbase);
+	g_car_array[0].front_yaw_factor = math_div(math_mul(car_specs.wheelbase, g_car_array[0].weight_distribution_front), aux);
+	g_car_array[0].rear_yaw_factor = math_div(math_mul(car_specs.wheelbase, g_car_array[0].weight_distribution_rear), aux);
 
-	player_car.collision_height_offset = 0x92f1;
-	player_car.collision_data.linear_acc_factor = 0xf646;
-	player_car.collision_data.angular_acc_factor = 0x7dd4;
-	player_car.collision_data.size.x = car_specs.body_width / 2;
-	player_car.collision_data.size.y = 0x92f1;
-	player_car.collision_data.size.z = car_specs.body_length / 2;
+	g_car_array[0].collision_height_offset = 0x92f1;
+	g_car_array[0].collision_data.linear_acc_factor = 0xf646;
+	g_car_array[0].collision_data.angular_acc_factor = 0x7dd4;
+	g_car_array[0].collision_data.size.x = car_specs.body_width / 2;
+	g_car_array[0].collision_data.size.y = 0x92f1;
+	g_car_array[0].collision_data.size.z = car_specs.body_length / 2;
 }
 
 /* basic game controls */
@@ -516,35 +516,35 @@ void tnfs_init_car() {
 void tnfs_controls_update() {
 	// steer ramp
 	if (g_control_steer > 0) {
-		player_car.steer_angle += 0x6C000;
-		if (player_car.steer_angle > 0x1B0000)
-			player_car.steer_angle = 0x1B0000;
+		g_car_array[0].steer_angle += 0x6C000;
+		if (g_car_array[0].steer_angle > 0x1B0000)
+			g_car_array[0].steer_angle = 0x1B0000;
 	} else if (g_control_steer < 0) {
-		player_car.steer_angle -= 0x6C000;
-		if (player_car.steer_angle < -0x1B0000)
-			player_car.steer_angle = -0x1B0000;
+		g_car_array[0].steer_angle -= 0x6C000;
+		if (g_car_array[0].steer_angle < -0x1B0000)
+			g_car_array[0].steer_angle = -0x1B0000;
 	} else {
-		player_car.steer_angle >>= 1;
+		g_car_array[0].steer_angle >>= 1;
 	}
 	// throttle ramp
 	if (g_control_throttle) {
-		player_car.throttle += 0x11;
-		if (player_car.throttle > 0xFF)
-			player_car.throttle = 0xFF;
+		g_car_array[0].throttle += 0x11;
+		if (g_car_array[0].throttle > 0xFF)
+			g_car_array[0].throttle = 0xFF;
 	} else {
-		player_car.throttle -= 0xC;
-		if (player_car.throttle < 0)
-			player_car.throttle = 0;
+		g_car_array[0].throttle -= 0xC;
+		if (g_car_array[0].throttle < 0)
+			g_car_array[0].throttle = 0;
 	}
 	// brake ramp
 	if (g_control_brake) {
-		player_car.brake += player_car.brake < 140 ? 0xC : 2;
-		if (player_car.brake > 0xFF)
-			player_car.brake = 0xFF;
+		g_car_array[0].brake += g_car_array[0].brake < 140 ? 0xC : 2;
+		if (g_car_array[0].brake > 0xFF)
+			g_car_array[0].brake = 0xFF;
 	} else {
-		player_car.brake -= 0x33;
-		if (player_car.brake < 0)
-			player_car.brake = 0;
+		g_car_array[0].brake -= 0x33;
+		if (g_car_array[0].brake < 0)
+			g_car_array[0].brake = 0;
 	}
 }
 
@@ -555,62 +555,62 @@ void tnfs_change_camera() {
 }
 
 void tnfs_change_gear_automatic(int shift) {
-	player_car.gear_auto_selected += shift;
+	g_car_array[0].gear_auto_selected += shift;
 
-	switch (player_car.gear_auto_selected) {
+	switch (g_car_array[0].gear_auto_selected) {
 	case 1:
-		player_car.gear_selected = -2;
-		player_car.is_gear_engaged = 1;
+		g_car_array[0].gear_selected = -2;
+		g_car_array[0].is_gear_engaged = 1;
 		printf("Gear: Reverse\n");
 		break;
 	case 2:
-		player_car.gear_selected = -1;
-		player_car.is_gear_engaged = 0;
+		g_car_array[0].gear_selected = -1;
+		g_car_array[0].is_gear_engaged = 0;
 		printf("Gear: Neutral\n");
 		break;
 	case 3:
-		player_car.gear_selected = 0;
-		player_car.is_gear_engaged = 1;
+		g_car_array[0].gear_selected = 0;
+		g_car_array[0].is_gear_engaged = 1;
 		printf("Gear: Drive\n");
 		break;
 	}
 }
 
 void tnfs_change_gear_manual(int shift) {
-	player_car.gear_selected += shift;
+	g_car_array[0].gear_selected += shift;
 
-	switch (player_car.gear_selected) {
+	switch (g_car_array[0].gear_selected) {
 	case -2:
-		player_car.is_gear_engaged = 1;
+		g_car_array[0].is_gear_engaged = 1;
 		printf("Gear: Reverse\n");
 		break;
 	case -1:
-		player_car.is_gear_engaged = 0;
+		g_car_array[0].is_gear_engaged = 0;
 		printf("Gear: Neutral\n");
 		break;
 	default:
-		player_car.is_gear_engaged = 1;
-		printf("Gear: %d\n", player_car.gear_selected + 1);
+		g_car_array[0].is_gear_engaged = 1;
+		printf("Gear: %d\n", g_car_array[0].gear_selected + 1);
 		break;
 	}
 }
 
 void tnfs_change_gear_up() {
-	if (player_car.gear_auto_selected == 0) {
-		if (player_car.gear_selected < car_specs.number_of_gears - 1)
+	if (g_car_array[0].gear_auto_selected == 0) {
+		if (g_car_array[0].gear_selected < car_specs.number_of_gears - 1)
 			tnfs_change_gear_manual(+1);
 	} else {
-		if (player_car.gear_auto_selected < 3)
+		if (g_car_array[0].gear_auto_selected < 3)
 			tnfs_change_gear_automatic(+1);
 	}
 }
 
 void tnfs_change_gear_down() {
-	if (player_car.gear_auto_selected == 0) {
-		if (player_car.gear_selected > -2)
+	if (g_car_array[0].gear_auto_selected == 0) {
+		if (g_car_array[0].gear_selected > -2)
 			tnfs_change_gear_manual(-1);
 	} else {
-		if (player_car.gear_auto_selected > 1)
+		if (g_car_array[0].gear_auto_selected > 1)
 			tnfs_change_gear_automatic(-1);
 	}
 }
@@ -618,46 +618,46 @@ void tnfs_change_gear_down() {
 /* additional features */
 
 void tnfs_abs() {
-	if (player_car.abs_enabled) {
-		player_car.abs_enabled = 0;
+	if (g_car_array[0].abs_enabled) {
+		g_car_array[0].abs_enabled = 0;
 		printf("ABS brakes off\n");
 	} else {
-		player_car.abs_enabled = 1;
+		g_car_array[0].abs_enabled = 1;
 		printf("ABS brakes on\n");
 	}
 }
 
 void tnfs_tcs() {
-	if (player_car.tcs_enabled) {
-		player_car.tcs_enabled = 0;
+	if (g_car_array[0].tcs_enabled) {
+		g_car_array[0].tcs_enabled = 0;
 		printf("Traction control off\n");
 	} else {
-		player_car.tcs_enabled = 1;
+		g_car_array[0].tcs_enabled = 1;
 		printf("Traction control on\n");
 	}
 }
 
 void tnfs_change_transmission_type() {
-	if (player_car.gear_auto_selected == 0) {
+	if (g_car_array[0].gear_auto_selected == 0) {
 		printf("Automatic Transmission mode\n");
-		player_car.gear_auto_selected = 2;
+		g_car_array[0].gear_auto_selected = 2;
 		tnfs_change_gear_automatic(0);
 	} else {
 		printf("Manual Transmission mode\n");
-		player_car.gear_auto_selected = 0;
+		g_car_array[0].gear_auto_selected = 0;
 		tnfs_change_gear_manual(0);
 	}
 }
 
 void tnfs_change_traction() {
-	if (player_car.car_specs_ptr->front_drive_percentage == 0x8000) {
-		player_car.car_specs_ptr->front_drive_percentage = 0x10000;
+	if (g_car_array[0].car_specs_ptr->front_drive_percentage == 0x8000) {
+		g_car_array[0].car_specs_ptr->front_drive_percentage = 0x10000;
 		printf("Traction: FWD\n");
-	} else if (player_car.car_specs_ptr->front_drive_percentage == 0) {
-		player_car.car_specs_ptr->front_drive_percentage = 0x8000;
+	} else if (g_car_array[0].car_specs_ptr->front_drive_percentage == 0) {
+		g_car_array[0].car_specs_ptr->front_drive_percentage = 0x8000;
 		printf("Traction: AWD\n");
 	} else {
-		player_car.car_specs_ptr->front_drive_percentage = 0;
+		g_car_array[0].car_specs_ptr->front_drive_percentage = 0;
 		printf("Traction: RWD\n");
 	}
 }
@@ -681,7 +681,7 @@ void tnfs_cheat_mode() {
 	}
 
 	tnfs_init_car();
-	tnfs_reset_car(&player_car);
+	tnfs_reset_car(g_car_ptr_array[0]);
 }
 
 void tnfs_crash_car() {
@@ -861,33 +861,27 @@ void tnfs_init_sim(char * trifile) {
 
 	tnfs_init_track(trifile);
 
-	g_car_ptr_array[0] = &player_car;
 	// init player car
 	tnfs_init_car();
-	player_car.car_data_ptr = &player_car;
-	player_car.car_specs_ptr = &car_specs;
-	player_car.road_segment_a = 18;
-	tnfs_reset_car(&player_car);
+	g_car_array[0].car_specs_ptr = &car_specs;
+	g_car_array[0].road_segment_a = 18;
+	tnfs_reset_car(&g_car_array[0]);
+  g_car_ptr_array[0] = &g_car_array[0];
 
 	// create xman car(s), player car copy
 	if (g_total_cars_in_scene > 1) {
-    struct tnfs_car_data additional_ai_drivers[g_total_cars_in_scene - 1];
     for (int i = 1; i < g_total_cars_in_scene; i++) {
-      if (i == 1) {
-        memcpy(&xman_car_data, &player_car, sizeof(tnfs_car_data));
-        g_car_ptr_array[1] = &xman_car_data;
-      } else {
-        memcpy(&additional_ai_drivers[i - 2], &player_car, sizeof(tnfs_car_data));
-        g_car_ptr_array[i] = &additional_ai_drivers[i - 2];
-      }
-      g_car_ptr_array[i]->car_data_ptr = g_car_ptr_array[i];
-      g_car_ptr_array[i]->car_specs_ptr = &car_specs;
-	    g_car_ptr_array[i]->road_segment_a = 18 + i * 2;
-      tnfs_reset_car(g_car_ptr_array[i]);
+      g_car_ptr_array[i] = &g_car_array[i];
+      memcpy(&g_car_array[i], &g_car_array[0], sizeof(tnfs_car_data));
+
+      g_car_array[i].car_data_ptr = g_car_ptr_array[i];
+      g_car_array[i].car_specs_ptr = &car_specs;
+	    g_car_array[i].road_segment_a = 18 + i * 2;
+      tnfs_reset_car(&g_car_array[i]);
       if (i % 2 == 1) {
-        g_car_ptr_array[i]->position.x -= 0x10000;
+        g_car_array[i].position.x -= 0x10000;
       } else {
-	      g_car_ptr_array[i]->position.x += 0x40000;
+	      g_car_array[i].position.x += 0x40000;
       }
     }
 	}
@@ -900,36 +894,35 @@ void tnfs_init_sim(char * trifile) {
 void tnfs_update() {
 	int node;
 	g_game_time++;
-
 	// update camera
 	switch (selected_camera) {
 	case 1: //heli cam
-		camera_position.x = player_car.position.x;
-		camera_position.y = player_car.position.y + 0x60000;
-		camera_position.z = player_car.position.z - 0x100000;
+		camera_position.x = g_car_array[0].position.x;
+		camera_position.y = g_car_array[0].position.y + 0x60000;
+		camera_position.z = g_car_array[0].position.z - 0x100000;
 		break;
 	case 2: //opponent cam
-		camera_position.x = xman_car_data.position.x;
-		camera_position.y = xman_car_data.position.y + 0x60000;
-		camera_position.z = xman_car_data.position.z - 0x100000;
+		camera_position.x = g_car_array[1].position.x;
+		camera_position.y = g_car_array[1].position.y + 0x60000;
+		camera_position.z = g_car_array[1].position.z - 0x100000;
 		break;
 	default: //chase cam
-		camera_position.x = player_car.position.x;
-		camera_position.y = player_car.position.y + 0x50000;
-		camera_position.z = player_car.position.z - 0x96000;
+		camera_position.x = g_car_array[0].position.x;
+		camera_position.y = g_car_array[0].position.y + 0x50000;
+		camera_position.z = g_car_array[0].position.z - 0x96000;
 		break;
 	}
 
 	// player
-	if (player_car.is_wrecked == 0) {
+	if (g_car_array[0].is_wrecked == 0) {
 		// driving mode loop
 		tnfs_controls_update();
-		tnfs_driving_main(&player_car);
+		tnfs_driving_main(g_car_ptr_array[0]);
 		// update render matrix
-		math_matrix_from_pitch_yaw_roll(&player_car.matrix, player_car.angle_x + player_car.body_pitch, player_car.angle_y, player_car.angle_z + player_car.body_roll);
+		math_matrix_from_pitch_yaw_roll(&g_car_array[0].matrix, g_car_array[0].angle_x + g_car_array[0].body_pitch, g_car_array[0].angle_y, g_car_array[0].angle_z + g_car_array[0].body_roll);
 	} else {
 		// crash mode loop
-		tnfs_collision_main(&player_car);
+		tnfs_collision_main(g_car_ptr_array[0]);
 	}
 
 	// opponent(s)
@@ -942,8 +935,8 @@ void tnfs_update() {
   }
 
 	// tweak to allow circuit track lap
-	if (player_car.road_segment_a == road_segment_count) {
-		player_car.road_segment_a = 0;
+	if (g_car_array[0].road_segment_a == road_segment_count) {
+		g_car_array[0].road_segment_a = 0;
 	}
 	for (int i = 1; i < g_total_cars_in_scene; i++) {
     if (g_car_ptr_array[i]->road_segment_a == road_segment_count - 5) {

--- a/tnfs_base.c
+++ b/tnfs_base.c
@@ -685,7 +685,9 @@ void tnfs_cheat_mode() {
 }
 
 void tnfs_crash_car() {
-	tnfs_collision_rollover_start(&xman_car_data, 0, 0, -0xa0000);
+  for (int i = 1; i < g_total_cars_in_scene; i++) {
+	  tnfs_collision_rollover_start(g_car_ptr_array[i], 0, 0, -0xa0000);
+  }
 }
 
 /* common stub functions */

--- a/tnfs_base.c
+++ b/tnfs_base.c
@@ -862,23 +862,35 @@ void tnfs_init_sim(char * trifile) {
 	tnfs_init_track(trifile);
 
 	g_car_ptr_array[0] = &player_car;
-	g_car_ptr_array[1] = &xman_car_data;
-
 	// init player car
 	tnfs_init_car();
 	player_car.car_data_ptr = &player_car;
 	player_car.car_specs_ptr = &car_specs;
+	player_car.road_segment_a = 18;
 	tnfs_reset_car(&player_car);
 
-	// create xman car, player car copy
-	memcpy(&xman_car_data, &player_car, sizeof(tnfs_car_data));
-	xman_car_data.car_data_ptr = &xman_car_data;
-	xman_car_data.car_specs_ptr = &car_specs;
-	tnfs_reset_car(&xman_car_data);
-
-	player_car.position.x += 0x40000;
-	xman_car_data.position.x -= 0x10000;
-
+	// create xman car(s), player car copy
+	if (g_total_cars_in_scene > 1) {
+    struct tnfs_car_data additional_ai_drivers[g_total_cars_in_scene - 1];
+    for (int i = 1; i < g_total_cars_in_scene; i++) {
+      if (i == 1) {
+        memcpy(&xman_car_data, &player_car, sizeof(tnfs_car_data));
+        g_car_ptr_array[1] = &xman_car_data;
+      } else {
+        memcpy(&additional_ai_drivers[i - 2], &player_car, sizeof(tnfs_car_data));
+        g_car_ptr_array[i] = &additional_ai_drivers[i - 2];
+      }
+      g_car_ptr_array[i]->car_data_ptr = g_car_ptr_array[i];
+      g_car_ptr_array[i]->car_specs_ptr = &car_specs;
+	    g_car_ptr_array[i]->road_segment_a = 18 + i * 2;
+      tnfs_reset_car(g_car_ptr_array[i]);
+      if (i % 2 == 1) {
+        g_car_ptr_array[i]->position.x -= 0x10000;
+      } else {
+	      g_car_ptr_array[i]->position.x += 0x40000;
+      }
+    }
+	}
 	tnfs_ai_init();
 }
 

--- a/tnfs_base.h
+++ b/tnfs_base.h
@@ -266,7 +266,11 @@ extern struct tnfs_car_specs car_specs;
 extern struct tnfs_car_data player_car;
 extern struct tnfs_track_data track_data[2400];
 extern struct tnfs_surface_type road_surface_type_array[3];
+
 extern struct tnfs_car_data xman_car_data;
+extern tnfs_car_data* g_car_ptr_array[8];
+extern int g_total_cars_in_scene;
+
 
 extern char is_drifting;
 extern int g_game_time;

--- a/tnfs_base.h
+++ b/tnfs_base.h
@@ -263,11 +263,10 @@ typedef struct tnfs_surface_type {
 
 // global variables
 extern struct tnfs_car_specs car_specs;
-extern struct tnfs_car_data player_car;
 extern struct tnfs_track_data track_data[2400];
 extern struct tnfs_surface_type road_surface_type_array[3];
 
-extern struct tnfs_car_data xman_car_data;
+extern struct tnfs_car_data g_car_array[8];
 extern tnfs_car_data* g_car_ptr_array[8];
 extern int g_total_cars_in_scene;
 

--- a/tnfs_collision_2d.c
+++ b/tnfs_collision_2d.c
@@ -67,7 +67,7 @@ void tnfs_collision_rotate(tnfs_car_data *car_data, int angle, int lon_speed, in
 			crash_pitch = fix6(crash_speed_a * (collisionAngle >> 16));
 		}
 		if (crash_yaw != 0) {
-			tnfs_collision_rollover_start(car_data->car_data_ptr, fix2(crash_yaw), fix2(3 * crash_roll), fix2(3 * crash_pitch));
+			tnfs_collision_rollover_start(car_data, fix2(crash_yaw), fix2(3 * crash_roll), fix2(3 * crash_pitch));
 		}
 	} else {
 		if (abs(collisionAngle) < 0x130000 && car_data->speed_local_lon > 0) {

--- a/tnfs_collision_3d.c
+++ b/tnfs_collision_3d.c
@@ -1604,58 +1604,65 @@ tnfs_vec3 g_col_direction;
  * manage car-to-car collisions - adapted/simplified from TNFS original
  */
 void tnfs_collision_carcar() {
-  if (g_total_cars_in_scene == 1) {
-    return;
-  };
-	// both cars are near
-	if (abs(player_car.position.x - xman_car_data.position.x) < 0x30000
-			&& abs(player_car.position.y - xman_car_data.position.y) < 0x30000
-			&& abs(player_car.position.z - xman_car_data.position.z) < 0x30000) {
+  for (int i = 0; i < g_total_cars_in_scene - 1; i++) {
+    for (int j = i + 1; j < g_total_cars_in_scene; j++) {
+      tnfs_car_data *carA = g_car_ptr_array[i];
+      tnfs_car_data *carB = g_car_ptr_array[j];
+      // both cars are near
+      if (abs(carA->position.x - carB->position.x) < 0x30000
+          && abs(carA->position.y - carB->position.y) < 0x30000
+          && abs(carA->position.z - carB->position.z) < 0x30000) {
 
-		g_col_position.x = 0;
-		g_col_position.y = 0;
-		g_col_position.z = 0;
-		g_col_direction.x = 0;
-		g_col_direction.y = 0;
-		g_col_direction.z = 0;
+        g_col_position.x = 0;
+        g_col_position.y = 0;
+        g_col_position.z = 0;
+        g_col_direction.x = 0;
+        g_col_direction.y = 0;
+        g_col_direction.z = 0;
 
-		// update collision structs
-		tnfs_collision_data_set(&player_car);
-		tnfs_collision_data_set(&xman_car_data);
+        // update collision structs
+        tnfs_collision_data_set(carA);
+        tnfs_collision_data_set(carB);
 
-		// if collided
-		if (tnfs_collision_carcar_box_detect(&player_car.collision_data, &xman_car_data.collision_data, &g_col_position, &g_col_direction)) {
+        // if collided
+        if (tnfs_collision_carcar_box_detect(&carA->collision_data, &carB->collision_data, &g_col_position, &g_col_direction)) {
 
-			// bounce off cars
-			tnfs_collision_carcar_rebound(&player_car.collision_data, &xman_car_data.collision_data, &g_col_position, &g_col_direction);
+          // bounce off cars
+          tnfs_collision_carcar_rebound(&carA->collision_data, &carB->collision_data, &g_col_position, &g_col_direction);
 
-			// FIXME xman always wrecked?
-			xman_car_data.is_wrecked = 1;
-			xman_car_data.field_4e1 = 4;
-			xman_car_data.collision_data.crash_time_ai_state = 300;
+          // FIXME xman always wrecked?
 
-			if (player_car.speed > 0x100000 && player_car.is_wrecked == 0) {
-				// big car wreck
-				player_car.is_wrecked = 1;
-				player_car.field_4e1 = 4;
-				player_car.collision_data.crash_time_ai_state = 300;
+	        carB->is_wrecked = 1;
+          carB->field_4e1 = 4;
+          carB->collision_data.crash_time_ai_state = 300;
 
-				// cinematic crash
-				tnfs_track_update_vectors(&player_car);
-				tnfs_track_update_vectors(&xman_car_data);
-				tnfs_collision_carcar_exageration(&player_car);
-				tnfs_collision_carcar_exageration(&xman_car_data);
-			}
+          if (carA->speed > 0x100000 && carA->is_wrecked == 0) {
+            // big car wreck
+            carA->is_wrecked = 1;
+            carA->field_4e1 = 4;
+            carA->collision_data.crash_time_ai_state = 300;
 
-      for (int i = 0; i < g_total_cars_in_scene; i++) {
-        if (g_car_ptr_array[i]->is_wrecked == 0) {
-          tnfs_collision_data_get(g_car_ptr_array[i]);
-          g_car_ptr_array[i]->speed_x = -g_car_ptr_array[i]->speed_x;
-          g_car_ptr_array[i]->speed_z = -g_car_ptr_array[i]->speed_z;
+            // cinematic crash
+            tnfs_track_update_vectors(carA);
+            tnfs_track_update_vectors(carB);
+            tnfs_collision_carcar_exageration(carA);
+            tnfs_collision_carcar_exageration(carB);
+          }
+
+          if (carA->is_wrecked == 0) {
+            tnfs_collision_data_get(carA);
+            carA->speed_x = -carA->speed_x;
+            carA->speed_z = -carA->speed_z;
+          }
+          if (carB->is_wrecked == 0) {
+            tnfs_collision_data_get(carB);
+            carB->speed_x = -carB->speed_x;
+            carB->speed_z = -carB->speed_z;
+          }
+
         }
       }
-
-		}
-	}
+    }
+  }
 }
 

--- a/tnfs_collision_3d.c
+++ b/tnfs_collision_3d.c
@@ -1604,6 +1604,9 @@ tnfs_vec3 g_col_direction;
  * manage car-to-car collisions - adapted/simplified from TNFS original
  */
 void tnfs_collision_carcar() {
+  if (g_total_cars_in_scene == 1) {
+    return;
+  };
 	// both cars are near
 	if (abs(player_car.position.x - xman_car_data.position.x) < 0x30000
 			&& abs(player_car.position.y - xman_car_data.position.y) < 0x30000

--- a/tnfs_collision_3d.c
+++ b/tnfs_collision_3d.c
@@ -1644,16 +1644,14 @@ void tnfs_collision_carcar() {
 				tnfs_collision_carcar_exageration(&xman_car_data);
 			}
 
-			if (player_car.is_wrecked == 0) {
-				tnfs_collision_data_get(&player_car);
-				player_car.speed_x = -player_car.speed_x;
-				player_car.speed_z = -player_car.speed_z;
-			}
-			if (xman_car_data.is_wrecked == 0) {
-				tnfs_collision_data_get(&xman_car_data);
-				xman_car_data.speed_x = -xman_car_data.speed_x;
-				xman_car_data.speed_z = -xman_car_data.speed_z;
-			}
+      for (int i = 0; i < g_total_cars_in_scene; i++) {
+        if (g_car_ptr_array[i]->is_wrecked == 0) {
+          tnfs_collision_data_get(g_car_ptr_array[i]);
+          g_car_ptr_array[i]->speed_x = -g_car_ptr_array[i]->speed_x;
+          g_car_ptr_array[i]->speed_z = -g_car_ptr_array[i]->speed_z;
+        }
+      }
+
 		}
 	}
 }

--- a/tnfs_collision_3d.c
+++ b/tnfs_collision_3d.c
@@ -322,7 +322,7 @@ void tnfs_collision_main(tnfs_car_data *car) {
 	car->is_crashed = 1;
 	collision_data = &car->collision_data;
 
-	if (car->car_data_ptr == (tnfs_car_data*) 0x0) {
+	if (car == (tnfs_car_data*) 0x0) {
 		aux = -car->rpm_engine + 1500;
 		if (aux < 0) {
 			aux += 1507;
@@ -400,10 +400,10 @@ void tnfs_collision_main(tnfs_car_data *car) {
 	iVar4 = 2;
 	if (DAT_800eae18 > 0) {
 		if (sound_flag == 0) {
-			tnfs_car_local_position_vector(car->car_data_ptr, &local_28, &local_24);
+			tnfs_car_local_position_vector(car, &local_28, &local_24);
 		}
 		if (car->collision_data.field6_0x60 > 0x80000) {
-			tnfs_car_local_position_vector(car->car_data_ptr, &local_28, &local_24);
+			tnfs_car_local_position_vector(car, &local_28, &local_24);
 			if (car->unknown_flag_475 == 0) {
 				local_24 = 1;
 				local_28 = 0x400000;

--- a/tnfs_dos_main.c
+++ b/tnfs_dos_main.c
@@ -82,9 +82,11 @@ void render() {
 	y = (float) car_data.position.x / 0x10000;
 	drawRoad(x - 10, y - 20, car_data.road_segment_a);
 
-	x -= (float) xman_car_data.position.z / 0x10000;
-	y -= (float) xman_car_data.position.x / 0x10000;
-	drawCar(&xman_car_data, 10 - x, 20 - y);
+  for (int i = 1; i < g_total_cars_in_scene; i++) {
+    x -= (float) g_car_ptr_array[i]->position.z / 0x10000;
+    y -= (float) g_car_ptr_array[i]->position.x / 0x10000;
+    drawCar(g_car_ptr_array[i], 10 - x, 20 - y);
+  }
 
 	drawCar(&car_data, 10, 20);
 }

--- a/tnfs_fiziks.c
+++ b/tnfs_fiziks.c
@@ -96,7 +96,9 @@ int tnfs_drag_force(tnfs_car_data *car, signed int speed, char longitudinal) {
  */
 void tnfs_cheat_crash_cars() {
 	if (cheat_crashing_cars == 4) {
-		tnfs_collision_rollover_start(&xman_car_data, 0xa0000, 0xa0000, 0xa0000);
+	  for (int i = 1; i < g_total_cars_in_scene; i++) {
+		  tnfs_collision_rollover_start(g_car_ptr_array[i], 0xa0000, 0xa0000, 0xa0000);
+    }
 	}
 }
 
@@ -627,7 +629,7 @@ void tnfs_physics_update(tnfs_car_data *car_data) {
 	sideslip = math_mul(car_data->wheel_base, car_data->fps * car_data->angular_speed);
 	speed_lat_front = aux - (drag_lat / 2) + sideslip;
 	speed_lat_rear = -(speed_lat + aux) - (drag_lat / 2) - sideslip;
-	
+
 	// longitudinal speeds, front and rear
 	aux = -math_mul(car_data->weight_distribution_front, speed_lon);
 	speed_lon_rear = -(speed_lon + aux) - (drag_lon / 2);

--- a/tnfs_sdl_main.c
+++ b/tnfs_sdl_main.c
@@ -33,7 +33,7 @@ void handleKeys() {
 			g_control_brake = 1;
 			break;
 		case SDLK_SPACE:
-			player_car.handbrake = 1;
+			g_car_array[0].handbrake = 1;
 			break;
 		}
 	}
@@ -46,7 +46,7 @@ void handleKeys() {
 			tnfs_change_gear_down();
 			break;
 		case SDLK_r:
-			tnfs_reset_car(&player_car);
+			tnfs_reset_car(g_car_ptr_array[0]);
 			break;
 		case SDLK_c:
 			tnfs_change_camera();
@@ -88,7 +88,7 @@ void handleKeys() {
 			g_control_steer = 0;
 			break;
 		case SDLK_SPACE:
-			player_car.handbrake = 0;
+			g_car_array[0].handbrake = 0;
 			break;
 		default:
 			break;
@@ -184,9 +184,9 @@ void drawRoad() {
 	for (int n = 0; n < 100; n++) {
 
 		if (selected_camera == 2) {
-			i = xman_car_data.road_segment_a;
+			i = g_car_array[1].road_segment_a;
 		} else {
-			i = player_car.road_segment_a;
+			i = g_car_array[0].road_segment_a;
 		}
 		i = i - 50 + n;
 		if (i < 0) {
@@ -217,7 +217,7 @@ void drawRoad() {
 
 void drawTach() {
 	float c,s,r;
-	r = ((float) player_car.rpm_engine / (float) player_car.rpm_redline) * 3.14 - 1.56;
+	r = ((float) g_car_array[0].rpm_engine / (float) g_car_array[0].rpm_redline) * 3.14 - 1.56;
 	c = -cosf(r);
 	s = sinf(r);
 
@@ -246,8 +246,9 @@ void renderGl() {
 	gluPerspective(90.0, 1, 0.1, 1000);
 
 	drawRoad();
-	drawVehicle(&player_car);
-	drawVehicle(&xman_car_data);
+	for (int i = 0; i < g_total_cars_in_scene; i++) {
+	  drawVehicle(g_car_ptr_array[i]);
+	}
 	drawTach();
 }
 

--- a/tnfs_win_main.c
+++ b/tnfs_win_main.c
@@ -249,9 +249,11 @@ void render() {
 	drawRoad(x - 30, y - 30, car_data.road_segment_a);
 	drawCar(&car_data, 30, 30);
 
-	x -= (float) xman_car_data.position.z / 0x10000;
-	y -= (float) xman_car_data.position.x / 0x10000;
-	drawCar(&xman_car_data, 30 - x, 30 - y);
+  for (int i = 1; i < g_total_cars_in_scene; i++) {
+    x -= (float) g_car_ptr_array[i]->position.z / 0x10000;
+    y -= (float) g_car_ptr_array[i]->position.x / 0x10000;
+    drawCar(g_car_ptr_array[i], 30 - x, 30 - y);
+  }
 
 	// hud text
 	sprintf(hud, "%d m/s - %d rpm - gear %d", car_data.speed_local_lon >> 16, car_data.rpm_engine, car_data.gear_selected + 1);


### PR DESCRIPTION
In this PR I refactored some code to support variable amount of AI racers (from 0 to 7). You can test it by changing new global variable `g_total_cars_in_scene`, value can be any from 1 to 8. Now pointer to player car is `g_car_ptr_array[0]`, legacy "xman" is `g_car_ptr_array[1]`. Fixed 3d collision logic to check collisions between all cars on stage.

Also, made start positions (Z) of cars to be exactly how it's done in TNFS: player starts on road segment 18, opponent on 20th, all the next AI racers on 22, 24 etc.

You can check how it works in my demo: https://tnfsw.guraklgames.com/, it already uses your physics engine + changes from this PR. Apart from AI racers wrecking each other, it seems to work well.

I'm not really a C developer, let me know if I can rewrite anything in a more convenient way